### PR TITLE
Fix install script markdown fences

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,3 @@
-```bash
 #!/usr/bin/env bash
 
 set -euo pipefail
@@ -237,5 +236,4 @@ printf '  Hyprland\n'
 
 printf '\n'
 success "Installation complete!"
-```
 


### PR DESCRIPTION
Removes the accidental Markdown code fences from install.sh.

The file currently starts with \`\`\`bash and ends with \`\`\`, which makes the installer invalid as a shell script and prevents it from executing correctly.

After removing the fences, install.sh is recognized and runs normally.